### PR TITLE
Remove redundant definitions from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,12 +7,6 @@
   "labels": [
     "dependencies"
   ],
-  "pip_requirements": {
-    "managerFilePatterns": ["(^|/)requirements[^/]*\\.txt$"]
-  },
-  "ansible-galaxy": {
-    "managerFilePatterns": ["(^|/)molecule/default/requirements\\.ya?ml$"]
-  },
   "pyenv": {
     "enabled": true
   },
@@ -30,17 +24,6 @@
       "automergeType": "branch",
       "schedule": ["* * 1 */6 *"],
       "automergeSchedule": ["* * 1-3 */6 *"]
-    },
-    {
-      "matchPackageNames": ["ansible", "ansible-core"],
-      "groupName": "ansible",
-      "groupSlug": "ansible"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/autobrr/autobrr"],
-      "groupName": "autobrr docker image",
-      "groupSlug": "autobrr"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Both `ansible-galaxy` and `pip_requirements` are discovered automatically, and Autobrr updates are discovered with the `matchStrings` variable.

See: https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/issues/1; Note that AnonymousOverflow does not release a tagged release, meaning nothing is found with `matchStrings`.